### PR TITLE
Add docs and license

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Node dependencies
+node_modules/
+
+# Build output
+/dist/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Mac
+.DS_Store

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 KingOfTheAce2
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# Mini Book Planner
+
+A simple React-based tool for planning the structure and content of a short book. It loads React from a CDN so it can run directly in the browser without a build step.
+
+## Running Locally
+Open `index.html` in your browser. The application will load and you can begin outlining chapters, subpoints and paragraphs.
+
+## Deploying to GitHub Pages
+1. Push the repository to GitHub.
+2. Enable GitHub Pages in the repository settings and choose the `main` branch as the source (or a `gh-pages` branch if preferred).
+3. The site will be served from `https://<username>.github.io/<repository>/`.
+
+## Features
+- Create a mini book outline from preset models.
+- Edit titles and content for chapters, subpoints and paragraphs.
+- Track word counts against target chapter lengths.
+- Import and export outlines as Markdown files.
+
+## Still To Implement
+The following improvements are planned but not yet implemented:
+
+1. Dynamic add/remove of subpoints and paragraphs.
+2. Support for nesting content deeper than the current chapter → subpoint → paragraph hierarchy.
+3. Next/Previous navigation buttons.
+4. Search functionality.
+5. Drag-and-drop reordering of chapters, subpoints and paragraphs.
+6. Export to DOCX in addition to Markdown.
+7. Rich text editing (bold, italics, lists, etc.).
+8. Table support.
+9. Enhanced spell check beyond the browser defaults.
+10. Character count and per-section goals.
+11. Import from Word or PDF.
+12. Dark mode toggle.
+13. User-adjustable font sizes.
+14. Estimated reading time per section.
+
+Contributions are welcome!
+
+## License
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
- add MIT license
- add ignore rules for Node projects
- document repo usage and future improvements

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685720ac1f2883298c79fa8e3052c765