### PR TITLE
Improve header layout and add intro section

### DIFF
--- a/app.jsx
+++ b/app.jsx
@@ -93,7 +93,7 @@ function App() {
 
   function initializeStructure(type) {
     const base = structures[type];
-    const chapters = base.chapters.map(ch => ({
+    const processed = base.chapters.map(ch => ({
       ...ch,
       content: '',
       subpoints: Array.from({ length: 3 }, (_, i) => ({
@@ -107,6 +107,22 @@ function App() {
         }))
       }))
     }));
+    const intro = {
+      id: '0',
+      title: 'Introduction',
+      content: '',
+      subpoints: Array.from({ length: 3 }, (_, i) => ({
+        id: `0.${i + 1}`,
+        title: `Subpoint ${i + 1}`,
+        content: '',
+        paragraphs: Array.from({ length: 3 }, (_, j) => ({
+          id: `0.${i + 1}.${j + 1}`,
+          title: `Paragraph ${j + 1}`,
+          content: ''
+        }))
+      }))
+    };
+    const chapters = [intro, ...processed];
     setMinibook(b => ({ ...b, structure: type, chapters }));
     setSelectedItem(null);
   }
@@ -408,7 +424,8 @@ function App() {
   return (
     <div className="container">
       <div className="header">
-        <h1>Minibook Planner <span className="credit">based on Chris Stanley's work</span></h1>
+        <h1>Mini Book Planner</h1>
+        <div className="credit">based on Chris Stanley's work</div>
 
         <div className="title-inputs">
           <input className="title-input" placeholder="Book Title" value={minibook.title}
@@ -417,13 +434,26 @@ function App() {
             onChange={e => setMinibook(b => ({ ...b, subtitle: e.target.value }))} />
         </div>
 
-      <div className="controls">
-        <select value={minibook.structure} onChange={e => initializeStructure(e.target.value)}>
-          <option value="sm">Select model...</option>
-          <option value="ws">W's Outline</option>
-          <option value="sequential">Sequential</option>
-          <option value="problems">10 Problems</option>
-        </select>
+        <div className="outline-length">
+          <label style={{ fontWeight: 600 }}>Outline Selector:</label>
+          <select value={minibook.structure} onChange={e => initializeStructure(e.target.value)}>
+            <option value="sm">Select model...</option>
+            <option value="ws">W's Outline</option>
+            <option value="sequential">Sequential</option>
+            <option value="problems">10 Problems</option>
+          </select>
+
+          <label style={{ fontWeight: 600 }}>Mini Book Length:</label>
+          <select value={lengthMode} onChange={e => setLengthMode(e.target.value)}>
+            {Object.entries(lengthGoals).map(([key, cfg]) => (
+              <option key={key} value={key}>
+                {`${cfg.name}: ${cfg.pages[0]}–${cfg.pages[1]} pages/chapter`}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="controls">
 
         <input
           type="text"
@@ -452,29 +482,18 @@ function App() {
           </button>
         </div>
 
-        <div style={{ marginTop: 20, textAlign: 'center' }}>
-          <label style={{ fontWeight: 600 }}>✍️ Mini Book Length:</label>
-          <select value={lengthMode} onChange={e => setLengthMode(e.target.value)} style={{ marginLeft: 8 }}>
-            {Object.entries(lengthGoals).map(([key, cfg]) => (
-              <option key={key} value={key}>
-                {`${cfg.name}: ${cfg.pages[0]}–${cfg.pages[1]} pages/chapter`}
-              </option>
-            ))}
-          </select>
-
-          <div style={{ marginTop: 8 }}>
-            <strong>Total words:</strong> {getTotalWordCount()} / Goal: {minibook.chapters.length * getGoalWordsPerChapter()}
-            <div style={{ marginTop: 4, height: 10, background: '#eee', borderRadius: 4 }}>
-              <div style={{
-                height: '100%',
-                background: getProgressColor((getTotalWordCount() / (minibook.chapters.length * getGoalWordsPerChapter())) * 100),
-                width: `${Math.min(100, (getTotalWordCount() / (minibook.chapters.length * getGoalWordsPerChapter())) * 100)}%`,
-                borderRadius: 4
-              }}></div>
-            </div>
-            <div style={{ marginTop: 4 }}>
-              <strong>Estimated reading:</strong> {getReadingTime()} min
-            </div>
+        <div className="stats">
+          <strong>Total words:</strong> {getTotalWordCount()} / Goal: {minibook.chapters.length * getGoalWordsPerChapter()}
+          <div className="progress-container">
+            <div style={{
+              height: '100%',
+              background: getProgressColor((getTotalWordCount() / (minibook.chapters.length * getGoalWordsPerChapter())) * 100),
+              width: `${Math.min(100, (getTotalWordCount() / (minibook.chapters.length * getGoalWordsPerChapter())) * 100)}%`,
+              borderRadius: 4
+            }}></div>
+          </div>
+          <div style={{ marginTop: 4 }}>
+            <strong>Estimated reading:</strong> {getReadingTime()} min
           </div>
         </div>
       </div>

--- a/style.css
+++ b/style.css
@@ -11,24 +11,27 @@ body {
 }
 
 .header {
-  background: #222;
-  color: #fff;
+  background: #fff;
+  color: #000;
   padding: 10px;
+  text-align: center;
 }
 
 .header .credit {
   font-size: 0.8em;
-  margin-left: 8px;
+  margin-top: 4px;
 }
 
 .title-inputs {
   display: flex;
+  flex-direction: column;
   gap: 8px;
   margin-top: 8px;
+  align-items: center;
 }
 
 .title-input, .subtitle-input {
-  flex: 1;
+  width: 100%;
   padding: 4px;
 }
 
@@ -36,6 +39,28 @@ body {
   margin-top: 8px;
   display: flex;
   gap: 8px;
+  justify-content: center;
+}
+
+.outline-length {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.stats {
+  margin-top: 12px;
+  text-align: center;
+}
+
+.progress-container {
+  margin: 4px auto;
+  height: 10px;
+  background: #eee;
+  border-radius: 4px;
+  max-width: 300px;
 }
 
 .main-content {
@@ -85,6 +110,7 @@ body.dark {
 
 body.dark .header {
   background: #333;
+  color: #fff;
 }
 
 body.dark .footer {


### PR DESCRIPTION
## Summary
- switch header to light theme by default
- center app title and tagline
- stack book title fields vertically
- add Outline selector and Mini Book Length section
- trim total words progress bar
- prepend Introduction chapter to all outlines

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6858f7aa53b48329acba829520c53959